### PR TITLE
fix dates for coffee chat 

### DIFF
--- a/app/knowledge_base.json
+++ b/app/knowledge_base.json
@@ -462,12 +462,12 @@
   {
     "id": 93,
     "about": "Defang Coffee Chat",
-    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our monthly Defang Coffee Chat. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. --- As always, we appreciate your feedback and are committed to making Defang the easiest way to develop, deploy, and debug your cloud applications. Go build something awesome! 🚀"
+    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Defang Coffee Chat on Oct 23rd. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/hlnq84xq\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> --- As always, we appreciate your feedback and are committed to making Defang the easiest way to develop, deploy, and debug your cloud applications. Go build something awesome! 🚀"
   },
   {
     "id": 94,
     "about": "Townhall",
-    "text": "If you're excited about what's coming next and want to hear more about our vision for the future, join us for our Townhall. We'll be sharing more about our roadmap and what we're working on next. We'll also be making sure to take time to answer any questions you have, hear your feedback, and learn more about what you want from Defang! --- We’re excited to keep improving Defang to make it the easiest way for you to Develop, Deploy, and Debug cloud application. Stay tuned for more updates next month."
+    "text": "If you're excited about what's coming next and want to hear more about our vision for the future, join us for our Townhall on August 21st. We'll be sharing more about our roadmap and what we're working on next. We'll also be making sure to take time to answer any questions you have, hear your feedback, and learn more about what you want from Defang! **[Register here](https://lu.ma/rlj13eq5)** --- We’re excited to keep improving Defang to make it the easiest way for you to Develop, Deploy, and Debug cloud application. Stay tuned for more updates next month."
   },
   {
     "id": 95,
@@ -512,7 +512,7 @@
   {
     "id": 103,
     "about": "Townhall",
-    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Townhall. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/9d8irae8\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> ---"
+    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Townhall on September 25th. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/9d8irae8\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> ---"
   },
   {
     "id": 104,

--- a/app/knowledge_base.json
+++ b/app/knowledge_base.json
@@ -462,12 +462,12 @@
   {
     "id": 93,
     "about": "Defang Coffee Chat",
-    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Defang Coffee Chat on Oct 23rd. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/hlnq84xq\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> --- As always, we appreciate your feedback and are committed to making Defang the easiest way to develop, deploy, and debug your cloud applications. Go build something awesome! 🚀"
+    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our monthly Defang Coffee Chat. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. --- As always, we appreciate your feedback and are committed to making Defang the easiest way to develop, deploy, and debug your cloud applications. Go build something awesome! 🚀"
   },
   {
     "id": 94,
     "about": "Townhall",
-    "text": "If you're excited about what's coming next and want to hear more about our vision for the future, join us for our Townhall on August 21st. We'll be sharing more about our roadmap and what we're working on next. We'll also be making sure to take time to answer any questions you have, hear your feedback, and learn more about what you want from Defang! **[Register here](https://lu.ma/rlj13eq5)** --- We’re excited to keep improving Defang to make it the easiest way for you to Develop, Deploy, and Debug cloud application. Stay tuned for more updates next month."
+    "text": "If you're excited about what's coming next and want to hear more about our vision for the future, join us for our Townhall. We'll be sharing more about our roadmap and what we're working on next. We'll also be making sure to take time to answer any questions you have, hear your feedback, and learn more about what you want from Defang! --- We’re excited to keep improving Defang to make it the easiest way for you to Develop, Deploy, and Debug cloud application. Stay tuned for more updates next month."
   },
   {
     "id": 95,
@@ -512,7 +512,7 @@
   {
     "id": 103,
     "about": "Townhall",
-    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Townhall on September 25th. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/9d8irae8\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> ---"
+    "text": "Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Townhall. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback. <Button href=\"https://lu.ma/9d8irae8\" variant=\"contained\" size=\"large\" target=\"_blank\"> Register here! </Button> ---"
   },
   {
     "id": 104,

--- a/app/rag_system.py
+++ b/app/rag_system.py
@@ -1,6 +1,7 @@
 import openai
 import json
 import os
+from datetime import date
 from sentence_transformers import SentenceTransformer
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
@@ -70,6 +71,7 @@ class RAGSystem:
                     "When the user says 'you', 'your', or any pronoun, interpret it as referring to Defang with context of Defang. "
                     "If the user's question involves comparisons with or references to other services, you may use external knowledge. "
                     "However, if the question is strictly about Defang, you must ignore all external knowledge and only utilize the given context. "
+                    "Today's date is " + date.today().strftime('%B %d, %Y') + "."
                     "Context: " + context
                 )
             }

--- a/app/rag_system.py
+++ b/app/rag_system.py
@@ -71,7 +71,7 @@ class RAGSystem:
                     "When the user says 'you', 'your', or any pronoun, interpret it as referring to Defang with context of Defang. "
                     "If the user's question involves comparisons with or references to other services, you may use external knowledge. "
                     "However, if the question is strictly about Defang, you must ignore all external knowledge and only utilize the given context. "
-                    "Today's date is " + date.today().strftime('%B %d, %Y') + "."
+                    "Today's date is " + date.today().strftime('%B %d, %Y') + ". "
                     "Context: " + context
                 )
             }


### PR DESCRIPTION
Removed actual dates (such as October 27th) and expired Luma invite links for Defang Coffee Chat/Townhall in `knowledge.json` as an attempt to avoid it giving out outdated dates/times for these events.

May still need some fixing elsewhere in order to for this change to take effect. Perhaps @Chrisyhjiang might know?