### PR TITLE
Added Ask-Token header to bypass CSRF and PoW when needed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,11 +34,12 @@ jobs:
       - name: Deploy
         uses: DefangLabs/defang-github-action@v1.1.3
         with:
-          config-env-vars: OPENAI_API_KEY SECRET_KEY SEGMENT_WRITE_KEY
+          config-env-vars: ASK_TOKEN OPENAI_API_KEY SECRET_KEY SEGMENT_WRITE_KEY
           mode: production
           provider: aws
           
         env:
+          ASK_TOKEN: ${{ secrets.ASK_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -9,6 +9,7 @@ services:
         protocol: tcp
         mode: ingress
     environment:
+      ASK_TOKEN: asktoken
       FLASK_APP: app.py
       SECRET_KEY: supersecret
       SEGMENT_WRITE_KEY: ${SEGMENT_WRITE_KEY} # Set your Segment write key here or in the .env file

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
         protocol: tcp
         mode: ingress
     environment:
+      ASK_TOKEN:
       FLASK_APP: app.py
       DEBUG: 0
       SECRET_KEY:


### PR DESCRIPTION
Added an `ASK_TOKEN` header variable so that the Discord bot can send requests to Ask Defang without requiring CSRF and Proof of Work (PoW) checks. 