### PR TITLE
Remove ephemeral flag for Discord Bot messages + specify Segment source

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -53,11 +53,14 @@ def handle_ask_request(request, session):
             full_response = "No response generated"
 
         if analytics.write_key:
+            # Determine the source based on the user agent
+            user_agent = request.headers.get('User-Agent', '')
+            source = 'Ask Defang Discord Bot' if 'Discord Bot' in user_agent else 'Ask Defang Website'
             # Track the query and response
             analytics.track(
                 anonymous_id=anonymous_id,
                 event='Chatbot Question submitted',
-                properties={'query': query, 'response': full_response, 'source': 'Ask Defang'}
+                properties={'query': query, 'response': full_response, 'source': source}
             )
 
     return Response(stream_with_context(generate()), content_type='text/markdown')

--- a/discord-bot/app.js
+++ b/discord-bot/app.js
@@ -96,6 +96,7 @@ async function fetchAnswer(question) {
     headers: {
       'Authorization': `Bearer ${process.env.ASK_TOKEN}`,
       'Content-Type': 'application/json',
+      'User-Agent': 'Discord Bot',
     },
     body: JSON.stringify({ query: question }),
   });

--- a/discord-bot/app.js
+++ b/discord-bot/app.js
@@ -39,7 +39,6 @@ function startLoadingDots(endpoint, initialMessage) {
     const loadingMessage = `${initialMessage}${'.'.repeat(dotCount)}`;
     const options = {
       content: loadingMessage,
-      flags: InteractionResponseFlags.EPHEMERAL,
       components: [],
     };
 
@@ -86,7 +85,6 @@ async function sendPlaceholderResponse(res, placeholderResponse) {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
       content: placeholderResponse,
-      flags: InteractionResponseFlags.EPHEMERAL,
       components: [], 
     },
   });
@@ -143,7 +141,6 @@ async function sendFollowUpResponse(endpoint, followUpMessage) {
   } else {
     let options = {
       content: followUpMessage,
-      flags: InteractionResponseFlags.EPHEMERAL,
       components: [],
     };
     await sendResponse(endpoint, options);


### PR DESCRIPTION
- Removed the ephemeral flag for Discord Bot messages, so now messages sent will be permanent 
- Improved detail for Segment analytics tracking: now differentiates between "Ask Defang Website" and "Ask Defang Discord Bot" as a source for the "Chatbot Question submitted" event