### PR TITLE
refactor RAGSystem initialization

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -49,4 +49,4 @@ RUN python test_intercom.py
 ENV FLASK_APP=app.py
 
 # Run the application using uWSGI
-CMD ["uwsgi", "--http", "0.0.0.0:5050", "--wsgi-file", "app.py", "--callable", "app", "--processes", "4", "--threads", "2"]
+CMD ["uwsgi", "--lazy-apps", "--http", "0.0.0.0:5050", "--wsgi-file", "app.py", "--callable", "app", "--processes", "4", "--threads", "2"]

--- a/app/rag_system.py
+++ b/app/rag_system.py
@@ -193,6 +193,3 @@ class RAGSystem:
         for doc in retrieved_docs:
             retrieved_text.append(f"{doc['about']}. {doc['text']}")
         return "\n\n".join(retrieved_text)
-
-# Instantiate the RAGSystem
-rag_system = RAGSystem()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,14 +1,13 @@
-from rag_system import rag_system
 import sys
 import traceback
 import segment.analytics as analytics
 
 # Shared function to generate response stream from RAG system
-def generate(query, source, anonymous_id):
+def generate(rag, query, source, anonymous_id):
     full_response = ""
     print(f"Received query: {str(query)}", file=sys.stderr)
     try:
-        for token in rag_system.answer_query_stream(query):
+        for token in rag.answer_query_stream(query):
             yield token
             full_response += token
     except Exception as e:
@@ -26,5 +25,5 @@ def generate(query, source, anonymous_id):
             event='Chatbot Question submitted',
             properties={'query': query, 'response': full_response, 'source': source}
         )
-    
+
     return full_response

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,6 @@ services:
       INTERCOM_TOKEN:
       INTERCOM_ADMIN_ID:
       REDIS_URL: redis://redis:6379/0
-    command: uwsgi --http 0.0.0.0:5050 --wsgi-file app.py --callable app --processes 4 --threads 2
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
This error has been in our logs for a long time:

```
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks
```

This is caused by initializing `SentenceTransformers` at the module scope and then `uwsgi` forking the process. Having `SentenceTransformers` disable parallelism is probably not a huge problem—it may just result in slower encodings. That said, there are a few reasons I think it's worth taking a look at this:
* `get_knowledge_base.py` is already very slow, and I'd like to try to keep inference as low latency as possible
* starting up a bunch of threads and forking a python process makes me nervous.

So, I think it's a good time to switch `uwsgi` to run in [`--lazy-apps` mode](https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#preforking-vs-lazy-apps-vs-lazy). This mode configures `uwsgi` to fork processes _before_ initializing the app, so each process runs with complete isolation. This will result in greater overall memory use, but I think the safety is probably worth it.

One alternative approach would be to move the embedding model to a single process (or compose service) and delegate to it for encodings.