### PR TITLE
gcp gateway edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 sentence-transformers
 .tmp/
 node_modules
+venv

--- a/app/rag_system.py
+++ b/app/rag_system.py
@@ -148,12 +148,12 @@ class RAGSystem:
             )
 
             collected_messages = []
-            for chunk in stream:
-                if chunk['choices'][0]['finish_reason'] is not None:
-                    break
+            for chunk in stream:  
                 content = chunk['choices'][0]['delta'].get('content', '')
                 collected_messages.append(content)
                 yield content
+                if chunk['choices'][0].get('finish_reason') is not None:
+                    break
 
             if len(citations) > 0:
                 yield "\n\nReferences:\n" + "\n".join(citations)


### PR DESCRIPTION
- Fixed an issue where we’d get a KeyError with GCP streaming responses.
- Fixed missing content from the last GCP chunk

In `rag_system.py`, I noticed that GCP chunks only include the `finish_reason` field on the last chunk (and not at all on earlier ones). AWS always includes `finish_reason` (it’s just null until the last chunk). Our code was trying to access `finish_reason` directly, which caused a `KeyError` when using the GCP gateway.

I switched to using `.get('finish_reason')` instead of `['finish_reason']`, so it won’t break if the field isn’t there. Also, I tweaked the logic so we still yield the last GCP chunk, even when it has both `content` and `finish_reason`—otherwise, we’d skip some text.