### PR TITLE
Add "depends-on" for app

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,9 @@ services:
       timeout: 10s
       retries: 5
       #start_period: 40s
+    depends_on:
+      - redis
+      - llm
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
Add depends-on for the `app` service to make sure the service starts up after other services have started