### PR TITLE
Add `start_period`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-      #start_period: 40s
+      start_period: 120s
     depends_on:
       - redis
       - llm


### PR DESCRIPTION
Add `start_period` to delay healthchecks so that there is enough time to download the SentenceTransformers model during deployments of docs-chatbot