### PR TITLE
add logging to determine connection issues

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
         mode: ingress
     environment:
       ASK_TOKEN:
+      DEBUG: 1
       FLASK_APP: app.py
       REBUILD_TOKEN:
       SECRET_KEY:
@@ -58,6 +59,7 @@ services:
         mode: host
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DEBUG=1
     healthcheck:
       test:
         - CMD


### PR DESCRIPTION
enable logging to debug production issues with connectivity. unable to reproduce errors in development and not enough information from production logs.