### PR TITLE
fix rebuild rigger

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -13,6 +13,7 @@ PyYAML==6.0.2
 GitPython==3.1.44
 redis==6.2.0
 fakeredis==2.30.1
+atomicwrites==1.4.1
 
 # linter
 ruff>=0.12.5

--- a/app/test_rag_system.py
+++ b/app/test_rag_system.py
@@ -1,6 +1,7 @@
 import unittest
 
 from rag_system import RAGSystem
+import os
 
 
 class TestRAGSystem(unittest.TestCase):
@@ -122,6 +123,79 @@ class TestRAGSystem(unittest.TestCase):
             )
 
         print("Test for compute_document_scores passed successfully!")
+
+    def test_cache_check_reload_cache(self):
+        # Simulate cache file timestamp change to trigger _reload_cache
+        original_doc_embeddings_timestamp = self.rag_system.doc_embeddings_timestamp
+        original_doc_about_embeddings_timestamp = (
+            self.rag_system.doc_about_embeddings_timestamp
+        )
+
+        # Patch os.path.getmtime to return different timestamps
+        def fake_getmtime(path):
+            if path == self.rag_system.DOC_EMBEDDINGS_PATH:
+                return original_doc_embeddings_timestamp + 1
+            if path == self.rag_system.DOC_ABOUT_EMBEDDINGS_PATH:
+                return original_doc_about_embeddings_timestamp + 1
+            return 0
+
+        self.rag_system._reload_cache_called = False
+
+        def fake_reload_cache():
+            self.rag_system._reload_cache_called = True
+            real_reload_cache()
+
+        real_getmtime = os.path.getmtime
+        os.path.getmtime = fake_getmtime
+
+        # Patch _reload_cache to set a flag
+        real_reload_cache = self.rag_system._reload_cache
+        self.rag_system._reload_cache = fake_reload_cache
+
+        # Call a cache_check-decorated method
+        self.rag_system.retrieve("test query")
+
+        self.assertTrue(
+            self.rag_system._reload_cache_called,
+            "Cache reload was not triggered when timestamps changed.",
+        )
+
+        # Restore patched methods
+        os.path.getmtime = real_getmtime
+        self.rag_system._reload_cache = real_reload_cache
+        print("Test for cache_check reload_cache passed successfully!")
+
+    def test_cache_check_rebuild_embeddings_on_error(self):
+        # Patch os.path.getmtime to raise OSError
+        real_getmtime = os.path.getmtime
+
+        def raise_oserror(path):
+            raise OSError("Simulated error")
+
+        os.path.getmtime = raise_oserror
+
+        self.rag_system._rebuild_embeddings_called = False
+
+        def fake_rebuild_embeddings():
+            self.rag_system._rebuild_embeddings_called = True
+            return real_rebuild_embeddings()
+
+        self.rag_system.rebuild_embeddings = fake_rebuild_embeddings
+        # Patch rebuild_embeddings to set a flag
+        real_rebuild_embeddings = self.rag_system.rebuild_embeddings
+
+        # Call a cache_check-decorated method
+        self.rag_system.retrieve("test query")
+
+        self.assertTrue(
+            self.rag_system._rebuild_embeddings_called,
+            "rebuild_embeddings was not triggered on cache access error.",
+        )
+
+        # Restore patched methods
+        os.path.getmtime = real_getmtime
+        self.rag_system.rebuild_embeddings = real_rebuild_embeddings
+        print("Test for cache_check rebuild_embeddings on error passed successfully!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change will return a response to the /trigger-rebuild end point after starting cache rebuild. Instead of waiting for refresh 
to complete. This change also fixes issue where only one thread handles /trigger-rebuild and so other threads aren't aware of cache changes. The timestamp of the cache files are check each time to be the most recent cache.

fixes [defang-docs #271](https://github.com/DefangLabs/defang-docs/issues/271)
fixes #105 